### PR TITLE
Simplify Singular Extension condition

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -257,10 +257,10 @@ enum Rank : int {
 };
 
 
-/// Score enum stores a middlegame and an endgame value in a single integer
-/// (enum). The least significant 16 bits are used to store the endgame value
-/// and the upper 16 bits are used to store the middlegame value. Take some
-/// care to avoid left-shifting a signed int to avoid undefined behavior.
+/// Score enum stores a middlegame and an endgame value in a single integer (enum).
+/// The least significant 16 bits are used to store the middlegame value and the
+/// upper 16 bits are used to store the endgame value. We have to take care to
+/// avoid left-shifting a signed int to avoid undefined behavior.
 enum Score : int { SCORE_ZERO };
 
 constexpr Score make_score(int mg, int eg) {


### PR DESCRIPTION
Avoid defining a singly used variable, removes one condition.
Score of OLDSING0 vs OLDSING1: 9 - 9 - 46  [0.500] 64

passed STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 53489 W: 10814 L: 10752 D: 31923
http://tests.stockfishchess.org/tests/view/5ac08a8d0ebc590e9457cd94

Closes https://github.com/official-stockfish/Stockfish/pull/1530

No functional change.