### PR TITLE
Simplify Tweak late move reductions at root.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1115,7 +1115,7 @@ moves_loop: // When in check, search starts from here
       // Step 16. Reduced depth search (LMR, ~200 Elo). If the move fails high it will be
       // re-searched at full depth.
       if (    depth >= 3
-          &&  moveCount > 1 + rootNode + (rootNode && bestValue < alpha)
+          &&  moveCount > 1 + 2 * rootNode
           && (!rootNode || thisThread->best_move_count(move) == 0)
           && (  !captureOrPromotion
               || moveCountPruning


### PR DESCRIPTION
Revert change from Jan 15.

STC 10+0.1 :
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 65135 W: 12543 L: 12436 D: 40156
Ptnml(0-2): 1090, 7618, 14947, 7623, 1136
https://tests.stockfishchess.org/tests/view/5e334016708b13464ceea32e

LTC 60+0.6 :
LLR: 2.95 (-2.94,2.94) {-1.50,0.50}
Total: 17768 W: 2286 L: 2191 D: 13291
Ptnml(0-2): 128, 1602, 5273, 1679, 140
https://tests.stockfishchess.org/tests/view/5e34011e57e1ecae66ec2aab

closes https://github.com/official-stockfish/Stockfish/pull/2537

Bench: 4914050