### PR TITLE
Simplify away king infiltration.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -701,9 +701,6 @@ namespace {
     int outflanking =  distance<File>(pos.square<KING>(WHITE), pos.square<KING>(BLACK))
                      - distance<Rank>(pos.square<KING>(WHITE), pos.square<KING>(BLACK));
 
-    bool infiltration =   rank_of(pos.square<KING>(WHITE)) > RANK_4
-                       || rank_of(pos.square<KING>(BLACK)) < RANK_5;
-
     bool pawnsOnBothFlanks =   (pos.pieces(PAWN) & QueenSide)
                             && (pos.pieces(PAWN) & KingSide);
 
@@ -715,11 +712,10 @@ namespace {
     int complexity =   9 * pe->passed_count()
                     + 11 * pos.count<PAWN>()
                     +  9 * outflanking
-                    + 12 * infiltration
                     + 21 * pawnsOnBothFlanks
                     + 51 * !pos.non_pawn_material()
                     - 43 * almostUnwinnable
-                    - 100 ;
+                    - 95 ;
 
     // Give more importance to non-material score
     Value mg = mg_value(score);


### PR DESCRIPTION
STC :
LLR: 2.94 (-2.94,2.94) {-1.50,0.50}
Total: 91438 W: 17496 L: 17438 D: 56504
Ptnml(0-2): 1573, 10711, 21067, 10790, 1563
https://tests.stockfishchess.org/tests/view/5e34812630ae32da08941d65

LTC :
LLR: 2.96 (-2.94,2.94) {-1.50,0.50}
Total: 40485 W: 5246 L: 5177 D: 30062
Ptnml(0-2): 289, 3818, 11976, 3812, 327
https://tests.stockfishchess.org/tests/view/5e354daee70d848499f6380c

closes https://github.com/official-stockfish/Stockfish/pull/2542

Bench: 5047825