### PR TITLE
Singular quiet LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -630,7 +630,8 @@ namespace {
     Depth extension, newDepth;
     Value bestValue, value, ttValue, eval, maxValue;
     bool ttHit, ttPv, formerPv, givesCheck, improving, didLMR, priorCapture;
-    bool captureOrPromotion, doFullDepthSearch, moveCountPruning, ttCapture, singularLMR;
+    bool captureOrPromotion, doFullDepthSearch, moveCountPruning,
+         ttCapture, singularQuietLMR;
     Piece movedPiece;
     int moveCount, captureCount, quietCount;
 
@@ -971,7 +972,7 @@ moves_loop: // When in check, search starts from here
                                       depth > 12 ? ss->ply : MAX_PLY);
 
     value = bestValue;
-    singularLMR = moveCountPruning = false;
+    singularQuietLMR = moveCountPruning = false;
     ttCapture = ttMove && pos.capture_or_promotion(ttMove);
 
     // Mark this node as being searched
@@ -1092,7 +1093,7 @@ moves_loop: // When in check, search starts from here
           if (value < singularBeta)
           {
               extension = 1;
-              singularLMR = true;
+              singularQuietLMR = !ttCapture;
           }
 
           // Multi-cut pruning
@@ -1198,7 +1199,7 @@ moves_loop: // When in check, search starts from here
               r--;
 
           // Decrease reduction if ttMove has been singularly extended (~3 Elo)
-          if (singularLMR)
+          if (singularQuietLMR)
               r -= 1 + formerPv;
 
           if (!captureOrPromotion)


### PR DESCRIPTION
If ttMove is a capture and had a singular extension, it is probably the best move.
No need to make a decrease of LMR on other moves.

STC
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 41968 W: 8170 L: 7918 D: 25880
Ptnml(0-2): 733, 4770, 9726, 5022, 733
https://tests.stockfishchess.org/tests/view/5ed6b666f29b40b0fc95a884

LTC
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 71376 W: 9200 L: 8827 D: 53349
Ptnml(0-2): 486, 6544, 21342, 6743, 573
https://tests.stockfishchess.org/tests/view/5ed7578bf29b40b0fc95a8c9

closes https://github.com/official-stockfish/Stockfish/pull/2713

Bench: 4733799